### PR TITLE
Attach the response body to error

### DIFF
--- a/gen/golang/templates/client.go.tmpl
+++ b/gen/golang/templates/client.go.tmpl
@@ -183,7 +183,7 @@ func errorFromResponse(resp *http.Response) Error {
   }
   var respErr Error
   if err := json.Unmarshal(respBody, &respErr); err != nil {
-    return Errorf(ErrInternal, err, "failed unmarshal error response")
+    return Errorf(ErrInternal, err, "failed unmarshal error response: %s", string(respBody))
   }
   return respErr
 }


### PR DESCRIPTION
Attaching the original response body in failure to unmarshal, so we can can learn about the underlying error.

Related to [LINC-347](https://linear.app/cohereai/issue/LINC-347/update-the-co-cli-to-return-real-underlying-error-to-avoid-confusion).